### PR TITLE
chore: use dind-runner-no-pvc for renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,7 +4,7 @@ on:
   - cron: '8/30 * * * *'
 jobs:
   renovate:
-    runs-on: dind-runner
+    runs-on: dind-runner-no-pvc
     steps:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Switch the Renovate workflow runner label to `dind-runner-no-pvc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)