### PR TITLE
chore: use sized cloud runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       directory: ./test/terraform
       terraform_version: "1.15.8"
-      runs-on: kubernetes-runner
+      runs-on: ubuntu-2404-x64-2core
       debug: true
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -24,7 +24,7 @@ jobs:
       GITHUB_APP_PEM_FILE: ${{ secrets.GH_APP_PEM_FILE }}
 
   verify-test-plan-reusable-workflow:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     needs: test-plan-reusable-workflow
     steps:
     - name: verify-terraform-plan
@@ -42,7 +42,7 @@ jobs:
       directory: ./test/terraform
       terraform_version: "1.15.8"
       environment: ''
-      runs-on: kubernetes-runner
+      runs-on: ubuntu-2404-x64-2core
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -51,7 +51,7 @@ jobs:
       GITHUB_APP_PEM_FILE: ${{ secrets.GH_APP_PEM_FILE }}
 
   verify-test-apply-reusable-workflow:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     needs: test-apply-reusable-workflow
     steps:
     - name: verify-terraform-apply
@@ -64,7 +64,7 @@ jobs:
         echo "${{ needs.test-apply-reusable-workflow.outputs.apply_output }}"
 
   test-plan:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-2404-x64-2core
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -86,7 +86,7 @@ jobs:
         github_app_pem_file: ${{ secrets.GH_APP_PEM_FILE }}
 
   verify-test-plan:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     needs: test-plan
     steps:
     - name: Verify plan outcome
@@ -99,7 +99,7 @@ jobs:
         echo "${{ needs.test-plan.outputs.plan_output }}"
 
   test-plan-for-apply-and-apply:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-2404-x64-2core
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -134,7 +134,7 @@ jobs:
         debug: true
 
   verify-plan-for-apply-and-apply:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     needs: test-plan-for-apply-and-apply
     steps:
     - name: Verify plan-for-apply outcome
@@ -153,7 +153,7 @@ jobs:
         echo "apply succeeded."
 
   test-encrypted-artifact-upload-download:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     steps:
     - name: Checkout Repo
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -196,7 +196,7 @@ jobs:
       run: diff -u plain.txt download/plain.txt
 
   check-workflow-status:
-    runs-on: kubernetes-runner
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       directory: ./test/terraform
       terraform_version: "1.15.8"
-      runs-on: ubuntu-2404-x64-2core
+      runs-on: ubuntu-latest
       debug: true
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -42,7 +42,7 @@ jobs:
       directory: ./test/terraform
       terraform_version: "1.15.8"
       environment: ''
-      runs-on: ubuntu-2404-x64-2core
+      runs-on: ubuntu-latest
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -64,7 +64,7 @@ jobs:
         echo "${{ needs.test-apply-reusable-workflow.outputs.apply_output }}"
 
   test-plan:
-    runs-on: ubuntu-2404-x64-2core
+    runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -99,7 +99,7 @@ jobs:
         echo "${{ needs.test-plan.outputs.plan_output }}"
 
   test-plan-for-apply-and-apply:
-    runs-on: ubuntu-2404-x64-2core
+    runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       GITHUB_APP_PEM_FILE: ${{ secrets.GH_APP_PEM_FILE }}
 
   verify-test-plan-reusable-workflow:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     needs: test-plan-reusable-workflow
     steps:
     - name: verify-terraform-plan
@@ -51,7 +51,7 @@ jobs:
       GITHUB_APP_PEM_FILE: ${{ secrets.GH_APP_PEM_FILE }}
 
   verify-test-apply-reusable-workflow:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     needs: test-apply-reusable-workflow
     steps:
     - name: verify-terraform-apply
@@ -86,7 +86,7 @@ jobs:
         github_app_pem_file: ${{ secrets.GH_APP_PEM_FILE }}
 
   verify-test-plan:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     needs: test-plan
     steps:
     - name: Verify plan outcome
@@ -134,7 +134,7 @@ jobs:
         debug: true
 
   verify-plan-for-apply-and-apply:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     needs: test-plan-for-apply-and-apply
     steps:
     - name: Verify plan-for-apply outcome
@@ -153,7 +153,7 @@ jobs:
         echo "apply succeeded."
 
   test-encrypted-artifact-upload-download:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -196,7 +196,7 @@ jobs:
       run: diff -u plain.txt download/plain.txt
 
   check-workflow-status:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -9,7 +9,7 @@ jobs:
   common:
     uses: eidp/actions-common/.github/workflows/common.yml@217646e29a87d3a4f92590c3186832354a9418d2 # v1.4.1
     with:
-      runs-on: ubuntu-slim
+      runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       issues: write

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -9,7 +9,7 @@ jobs:
   common:
     uses: eidp/actions-common/.github/workflows/common.yml@217646e29a87d3a4f92590c3186832354a9418d2 # v1.4.1
     with:
-      runs-on: kubernetes-runner
+      runs-on: ubuntu-slim
     permissions:
       pull-requests: write
       issues: write

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,7 +4,7 @@ on:
   - cron: '8/30 * * * *'
 jobs:
   renovate:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-2404-x64-2core
     steps:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,7 +4,7 @@ on:
   - cron: '8/30 * * * *'
 jobs:
   renovate:
-    runs-on: dind-runner-no-pvc
+    runs-on: ubuntu-slim
     steps:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,7 +4,7 @@ on:
   - cron: '8/30 * * * *'
 jobs:
   renovate:
-    runs-on: ubuntu-2404-x64-2core
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ The following reusable workflows are available in this repository:
 The following GitHub Actions are available in this repository:
 
 - [apply](apply/README.md)
-- [download-encrypted-artifact](download-encrypted-artifact/README.md)
 - [plan](plan/README.md)
 - [plan-for-apply](plan-for-apply/README.md)
 - [upload-encrypted-artifact](upload-encrypted-artifact/README.md)
+- [download-encrypted-artifact](download-encrypted-artifact/README.md)
 
 <!-- END ACTIONS -->


### PR DESCRIPTION
## Summary

Moves this repo's CI jobs off the shared `kubernetes-runner`/`dind-runner`/`dind-runner-no-pvc` labels onto sized runners provisioned for what each job actually needs.

<details>
<summary><b>Evidence bundle</b></summary>

### Intent

No ticket. Follows the runner-consolidation pattern already merged in eidp/eidp-api (#1008): the shared `kubernetes-runner`/`dind-runner` pools were a one-size-fits-all default — `dind-runner` for anything Docker-ish, `kubernetes-runner` for everything else — regardless of what a given job actually needed. This reclassifies each job in this repo's CI by what it does: `ubuntu-slim` if it needs neither Docker nor a live cluster, `ubuntu-latest` if it needs Docker/real work but only talks to public APIs (no internal network access), `ubuntu-2404-x64-2core`/`-4core` reserved for jobs that need our internal cluster/VPC or are genuinely resource-intensive.

### Context

Two corrections made along the way, both reflected in this diff:
- The `renovate` job runs on `ubuntu-latest`, not a self-hosted label — `eidp/actions-common/renovate` pulls and runs `cr.eidp.io/docker/renovate/renovate` via `renovatebot/github-action`, which `ubuntu-slim` can't do, and GitHub-hosted is cheaper than reserving self-hosted capacity for a scheduled bot job.
- The `plan`/`apply`/`test-plan`/`test-plan-for-apply-and-apply` jobs were initially landed on `ubuntu-2404-x64-2core` (this repo's Terraform actions need real credentials/state, which looked self-hosted-worthy), but they only call AWS's and GitHub's public APIs — no internal cluster/VPC access — so they moved to `ubuntu-latest` too. Self-hosted capacity was buying nothing there.

### Rollback

Revert this commit and merge; the old `kubernetes-runner`/`dind-runner` labels are untouched elsewhere and remain available as a fallback. Not yet tested — I haven't run this branch's pipeline, so confirm the reclassified jobs actually succeed before merging.

### Risk hunks

1. Every job moved to `ubuntu-slim`/`ubuntu-latest` in this diff assumes it needs neither Docker-with-internal-access nor a live cluster. That assumption was wrong twice already in this migration (the `renovate` job, and the terraform plan/apply jobs both needed a second pass) — accepted, but this repo in particular is worth a careful look given how much moved.
2. `build.yml`'s jobs were renamed and restructured on `main` since this branch's base (terraform version bump, several jobs renamed/added) — the reclassification was redone directly against current `main` rather than merged from the stale diff, so it wasn't re-reviewed against the original per-job judgment calls.

</details>

## Out of scope

Whether the Docker build/push jobs across the rest of the org (pushing to `cr.eidp.io`) could similarly move to `ubuntu-latest` if that registry is reachable from the public internet rather than only from inside our VPC — raised but not resolved here; left for a separate pass once that's confirmed.
